### PR TITLE
issue/22 ✨ user api&dto 4개 추가, user domain에 birth column 추가/ ➕  @NotBlank 적용 위해 gradle 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/zipdabang/server/converter/SmsConverter.java
+++ b/src/main/java/zipdabang/server/converter/SmsConverter.java
@@ -1,0 +1,17 @@
+package zipdabang.server.converter;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import zipdabang.server.base.Code;
+import zipdabang.server.sms.dto.SmsResponseDto;
+
+@Component
+@RequiredArgsConstructor
+public class SmsConverter {
+
+    public static SmsResponseDto.AuthNumResultDto toAuthNumResultDto(Code responseCode) {
+        return SmsResponseDto.AuthNumResultDto.builder()
+                .responseCode(responseCode)
+                .build();
+    }
+}

--- a/src/main/java/zipdabang/server/converter/UserConverter.java
+++ b/src/main/java/zipdabang/server/converter/UserConverter.java
@@ -1,0 +1,19 @@
+package zipdabang.server.converter;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import zipdabang.server.domain.Users;
+import zipdabang.server.web.dto.responseDto.UserResponseDto;
+
+@Component
+@RequiredArgsConstructor
+public class UserConverter {
+
+    public static UserResponseDto.JoinUserDto toJoinUserDto(Users user) {
+        return UserResponseDto.JoinUserDto.builder()
+                .userId(user.getUserId())
+                .nickname(user.getNickname())
+//                .accessToken()
+                .build();
+    }
+}

--- a/src/main/java/zipdabang/server/converter/common/BaseConverter.java
+++ b/src/main/java/zipdabang/server/converter/common/BaseConverter.java
@@ -1,0 +1,18 @@
+package zipdabang.server.converter.common;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import zipdabang.server.base.Code;
+import zipdabang.server.web.dto.common.BaseDto;
+
+@Component
+@RequiredArgsConstructor
+public class BaseConverter {
+
+    public static BaseDto.BaseResponseDto toBaseDto(Code responseCode, Object result) {
+        return BaseDto.BaseResponseDto.builder()
+                .code(responseCode.getCode())
+                .message(responseCode.getMessage())
+                .build();
+    }
+}

--- a/src/main/java/zipdabang/server/domain/Users.java
+++ b/src/main/java/zipdabang/server/domain/Users.java
@@ -37,14 +37,18 @@ public class Users extends BaseEntity {
     @Column(length = 18)
     private String phoneNum;
 
+    @Column(length = 6)
+    private String birth;
+
     private Integer age;
 
     @Enumerated(EnumType.STRING)
     private GenderType gender;
 
-    private String address;
     @Column(length = 5)
     private String zipCode;
+
+    private String address;
 
     private String detailAddress;
 

--- a/src/main/java/zipdabang/server/sms/dto/SmsResponseDto.java
+++ b/src/main/java/zipdabang/server/sms/dto/SmsResponseDto.java
@@ -1,0 +1,25 @@
+package zipdabang.server.sms.dto;
+
+import lombok.*;
+import zipdabang.server.base.Code;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SmsResponseDto {
+    String requestId;
+    LocalDateTime requestTime;
+    String statusCode;
+    String statusName;
+
+    @Builder
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class AuthNumResultDto{
+        Code responseCode;
+    }
+}

--- a/src/main/java/zipdabang/server/utils/OAuthResult.java
+++ b/src/main/java/zipdabang/server/utils/OAuthResult.java
@@ -1,0 +1,19 @@
+package zipdabang.server.utils;
+
+import lombok.*;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OAuthResult {
+
+    @Builder
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class OAuthResultDto{
+        Boolean isLogin;
+        String jwt;
+        Long userId;
+    }
+}

--- a/src/main/java/zipdabang/server/web/controller/UserRestController.java
+++ b/src/main/java/zipdabang/server/web/controller/UserRestController.java
@@ -19,7 +19,7 @@ public class UserRestController {
     //소셜로그인
     @PostMapping("/users/oauth")
     public ResponseDto<OAuthResult.OAuthResultDto> oauth(
-            @PathVariable String type,
+            @PathVariable("type") String type,
             @RequestBody UserRequestDto.KakaoSocialDto kakaoRequest,
             @RequestBody UserRequestDto.AppleSocialDto appleRequest) {
 

--- a/src/main/java/zipdabang/server/web/controller/UserRestController.java
+++ b/src/main/java/zipdabang/server/web/controller/UserRestController.java
@@ -1,0 +1,46 @@
+package zipdabang.server.web.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import zipdabang.server.base.ResponseDto;
+import zipdabang.server.sms.dto.SmsResponseDto;
+import zipdabang.server.utils.OAuthResult;
+import zipdabang.server.web.dto.requestDto.UserRequestDto;
+import zipdabang.server.web.dto.responseDto.UserResponseDto;
+
+import java.io.IOException;
+
+@RestController
+@Validated
+@RequiredArgsConstructor
+public class UserRestController {
+
+    //소셜로그인
+    @PostMapping("/users/oauth")
+    public ResponseDto<OAuthResult.OAuthResultDto> oauth(
+            @PathVariable String type,
+            @RequestBody UserRequestDto.KakaoSocialDto kakaoRequest,
+            @RequestBody UserRequestDto.AppleSocialDto appleRequest) {
+
+        return null;
+    }
+
+    //회원 정보 추가입력
+    @PostMapping("/users/oauth/info")
+    public ResponseDto<UserResponseDto.JoinUserDto> userInfoForSignUp(@RequestBody UserRequestDto.UserInfoDto request) {
+        return null;
+    }
+
+    //인증번호 요청
+    @PostMapping("/users/phone/sms")
+    public ResponseDto<Integer> sendSms(@RequestBody UserRequestDto.SmsRequestDto request){
+        return null;
+    }
+
+    //인증번호 검증
+    @PostMapping("/users/phone/auth")
+    public ResponseDto<SmsResponseDto.AuthNumResultDto> authPhoneNum(@RequestBody UserRequestDto.PhoneNumAuthDto request){
+        return null;
+    }
+}

--- a/src/main/java/zipdabang/server/web/controller/UserRestController.java
+++ b/src/main/java/zipdabang/server/web/controller/UserRestController.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 public class UserRestController {
 
     //소셜로그인
-    @PostMapping("/users/oauth")
+    @PostMapping("/users/oauth/{type}")
     public ResponseDto<OAuthResult.OAuthResultDto> oauth(
             @PathVariable("type") String type,
             @RequestBody UserRequestDto.KakaoSocialDto kakaoRequest,

--- a/src/main/java/zipdabang/server/web/dto/common/BaseDto.java
+++ b/src/main/java/zipdabang/server/web/dto/common/BaseDto.java
@@ -1,0 +1,15 @@
+package zipdabang.server.web.dto.common;
+
+import lombok.*;
+
+public class BaseDto {
+
+    @Builder
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class BaseResponseDto {
+        private Integer code;
+        private String message;
+    }
+}

--- a/src/main/java/zipdabang/server/web/dto/requestDto/UserRequestDto.java
+++ b/src/main/java/zipdabang/server/web/dto/requestDto/UserRequestDto.java
@@ -1,0 +1,89 @@
+package zipdabang.server.web.dto.requestDto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotBlank;
+import java.util.List;
+
+public class UserRequestDto {
+
+    @Getter
+    @Setter
+    public static class KakaoSocialDto {
+        @Override
+        public String toString() {
+            return "KakaoSocialDto{" +
+                    "socialId='" + socialId + '\'' +
+                    "}";
+        }
+
+        private String socialId;
+    }
+
+    @Getter
+    @Setter
+    public static class AppleSocialDto{
+        @Override
+        public String toString() {
+            return "AppleSocialDto{" +
+                    "identityToken='" + identityToken + '\'' +
+                    "}";
+        }
+
+        private String identityToken;
+    }
+
+    @Getter
+    @Setter
+    public static class UserInfoDto{
+
+
+        @NotBlank
+        private String name;
+        @NotBlank
+        private String birth;
+        @NotBlank
+        private String gender;
+        @NotBlank
+        private String zipCode;
+        @NotBlank
+        private String address;
+        @NotBlank
+        private String detailAddress;
+        @NotBlank
+        private String nickname;
+
+        private List<Integer> preferBeverages;
+
+    }
+
+    @Getter
+    @Setter
+    public static class SmsRequestDto{
+        @Override
+        public String toString() {
+            return "SmsRequestDto{" +
+                    "targetPhoneNum='" + targetPhoneNum + '\'' +
+                    '}';
+        }
+
+        private String targetPhoneNum;
+    }
+
+    @Getter
+    @Setter
+    public static class PhoneNumAuthDto {
+        @Override
+        public String toString() {
+            return "PhoneNumAuthDto{" +
+                    "phoneNum='" + phoneNum + '\'' +
+                    ", authNum=" + authNum +
+                    '}';
+        }
+
+        private String phoneNum;
+        private Integer authNum;
+    }
+
+}

--- a/src/main/java/zipdabang/server/web/dto/responseDto/UserResponseDto.java
+++ b/src/main/java/zipdabang/server/web/dto/responseDto/UserResponseDto.java
@@ -4,13 +4,14 @@ import lombok.*;
 
 public class UserResponseDto {
 
+
     @Builder
     @Getter
     @AllArgsConstructor(access = AccessLevel.PROTECTED)
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    public static class JoinUserDto{
+    public static class JoinUserDto {
         private Long userId;
-//        private String nickname;
+        private String nickname;
         private String accessToken;
     }
 }

--- a/src/main/java/zipdabang/server/web/dto/responseDto/UserResponseDto.java
+++ b/src/main/java/zipdabang/server/web/dto/responseDto/UserResponseDto.java
@@ -1,0 +1,16 @@
+package zipdabang.server.web.dto.responseDto;
+
+import lombok.*;
+
+public class UserResponseDto {
+
+    @Builder
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class JoinUserDto{
+        private Long userId;
+//        private String nickname;
+        private String accessToken;
+    }
+}


### PR DESCRIPTION
social login 카카오랑 구글 로직 보니까 많이 달라서 path variable로 구분하지 말고 api를 따로 나누는게 더 편하지 않을까..하는 생각이 들었습니다. 앞으로 네이버 구글 로그인도 추가된다면 api 하나에서 처리하기 넘 많으니까!

+) 소셜 로그인 response dto는 serviceImpl에서 채워주는 것 같아서 converter 추가 안했음