### PR TITLE
Feature/53 ✨  레시피 api, dto 추가(임시저장, 댓글 제외)

### DIFF
--- a/src/main/java/zipdabang/server/auth/provider/TokenProvider.java
+++ b/src/main/java/zipdabang/server/auth/provider/TokenProvider.java
@@ -45,7 +45,7 @@ public class TokenProvider implements InitializingBean {
 
     public TokenProvider(@Value("${jwt.secret}") String secret,
                          @Value("${jwt.authorities-key}") String authoritiesKey,
-                         @Value("${jwt.access-token-validity-in-seconds}") long accessTokenValidityInMilliseconds){
+                         @Value("${jwt.access-token-validity-in-seconds}000") long accessTokenValidityInMilliseconds){
         this.secret = secret;
         this.AUTHORITIES_KEY = authoritiesKey;
         this.accessTokenValidityInMilliseconds = accessTokenValidityInMilliseconds;

--- a/src/main/java/zipdabang/server/base/Code.java
+++ b/src/main/java/zipdabang/server/base/Code.java
@@ -26,6 +26,9 @@ public enum Code {
 
     WATCHED_NOT_FOUND(HttpStatus.OK, 2060, "조회했던 아이템이 없습니다."),
 
+    //recipe response
+    RECIPE_NOT_FOUND(HttpStatus.OK, 2100, "해당되는 레시피가 없습니다"),
+
     // error Codes
 
     JWT_FORBIDDEN(HttpStatus.FORBIDDEN, 4002, "이미 로그아웃 된 토큰입니다."),
@@ -51,6 +54,9 @@ public enum Code {
 
 
     // market error
+
+    //recipe error
+    NULL_RECIPE_ERROR(HttpStatus.BAD_REQUEST, 4100, "레시피 작성시 누락된 내용이 있습니다."),
 
 
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5000, "Internal server Error"),

--- a/src/main/java/zipdabang/server/base/Code.java
+++ b/src/main/java/zipdabang/server/base/Code.java
@@ -27,7 +27,7 @@ public enum Code {
     WATCHED_NOT_FOUND(HttpStatus.OK, 2060, "조회했던 아이템이 없습니다."),
 
     //recipe response
-    RECIPE_NOT_FOUND(HttpStatus.OK, 2100, "해당되는 레시피가 없습니다"),
+    RECIPE_NOT_FOUND(HttpStatus.OK, 2100, "검색어와 일치하는 레시피가 없습니다"),
 
     // error Codes
 
@@ -57,6 +57,7 @@ public enum Code {
 
     //recipe error
     NULL_RECIPE_ERROR(HttpStatus.BAD_REQUEST, 4100, "레시피 작성시 누락된 내용이 있습니다."),
+    NO_RECIPE_EXIST(HttpStatus.BAD_REQUEST, 4101, "해당 레시피가 존재하지 않습니다."),
 
 
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5000, "Internal server Error"),

--- a/src/main/java/zipdabang/server/domain/recipe/Comment.java
+++ b/src/main/java/zipdabang/server/domain/recipe/Comment.java
@@ -22,10 +22,7 @@ public class Comment extends BaseEntity {
     private Long id;
 
     @Column(columnDefinition = "TEXT")
-    private String imageUrl;
-
-    @Column(columnDefinition = "TEXT")
-    private String contents;
+    private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)

--- a/src/main/java/zipdabang/server/domain/recipe/Recipe.java
+++ b/src/main/java/zipdabang/server/domain/recipe/Recipe.java
@@ -34,6 +34,11 @@ public class Recipe extends BaseEntity {
     @Column(length = 500)
     private String intro;
 
+    @Column(length = 500)
+    private String recipeTip;
+
+    private String time;
+
     private Float starScore;
     @Column(columnDefinition = "BIGINT DEFAULT 0")
     private Long totalView;

--- a/src/main/java/zipdabang/server/domain/recipe/Step.java
+++ b/src/main/java/zipdabang/server/domain/recipe/Step.java
@@ -21,7 +21,6 @@ public class Step extends BaseEntity {
     @Column(nullable = false)
     private Long id;
 
-    private String title;
     private Integer stepNum;
 
     @Column(columnDefinition = "TEXT")

--- a/src/main/java/zipdabang/server/redis/service/RedisServiceImpl.java
+++ b/src/main/java/zipdabang/server/redis/service/RedisServiceImpl.java
@@ -46,7 +46,7 @@ public class RedisServiceImpl implements RedisService {
         LocalDateTime currentTime = LocalDateTime.now();
 
         // test를 할 때는 plus 인자를 짧게
-        LocalDateTime expireTime = currentTime.plus(1, ChronoUnit.MINUTES);
+        LocalDateTime expireTime = currentTime.plus(1000, ChronoUnit.MINUTES);
 
         return refreshTokenRepository.save(
                 RefreshToken.builder()

--- a/src/main/java/zipdabang/server/web/controller/RecipeController.java
+++ b/src/main/java/zipdabang/server/web/controller/RecipeController.java
@@ -1,14 +1,17 @@
 package zipdabang.server.web.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import zipdabang.server.auth.handler.annotation.AuthMember;
 import zipdabang.server.base.ResponseDto;
 import zipdabang.server.domain.member.Member;
@@ -19,13 +22,72 @@ import zipdabang.server.web.dto.responseDto.RecipeResponseDto;
 @Validated
 @RequiredArgsConstructor
 @Tag(name = "레시피 관련 API", description = "레시피 관련 API 모음입니다.")
-public class RecipeController {
+public class
+RecipeController {
 
+    /*
     @Parameters({
             @Parameter(name = "member", hidden = true)
     })
     @PostMapping(value = "/members/recipes",consumes = { MediaType.MULTIPART_FORM_DATA_VALUE })
     public ResponseDto<RecipeResponseDto.RecipeStatusDto> createRecipe(@ModelAttribute RecipeRequestDto.CreateRecipeDto request, @AuthMember Member member){
+        return null;
+    }
+     */
+
+    @Operation(summary = "🍹figma 레시피 작성하기1, 레시피 등록 API 🔑", description = "레시피 (작성)등록 화면 API입니다. 임시저장 api는 별도로 있음. step이랑 ingredient 몇개 들어오는지 각Count에 적어주세요")
+    @ApiResponses({
+            @ApiResponse(responseCode = "2000"),
+            @ApiResponse(responseCode = "4006",description = "UNAUTHORIZED, 토큰 모양이 이상함, 토큰 제대로 주세요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4007",description = "UNAUTHORIZED, 엑세스 토큰 만료, 리프레시 토큰 사용",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4010",description = "UNAUTHORIZED, 토큰 없음, 토큰 줘요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4013",description = "BAD_REQUEST, 사용자가 없습니다. 이 api에서 이거 생기면 백앤드 개발자 호출",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4100", description = "레시피 작성시 누락된 내용이 있습니다. 미완료는 임시저장으로 가세요", content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "5000",description = "SERVER ERROR, 백앤드 개발자에게 알려주세요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+    })
+    @Parameters({
+            @Parameter(name = "member", hidden = true),
+    })
+    @PostMapping(value = "/members/recipes", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ResponseDto<RecipeResponseDto.CreateRecipeDto> createRecipe(@ModelAttribute RecipeRequestDto.CreateRecipeDto request, @AuthMember Member member){
+        return null;
+    }
+
+    @Operation(summary = "🍹figma 레시피 상세페이지, 레시피 상세 정보 조회 API 🔑", description = "레시피 조회 화면 API입니다. 댓글은 처음 10개만 가져오고 나머지는 댓글 page api 드림")
+    @ApiResponses({
+            @ApiResponse(responseCode = "2000"),
+            @ApiResponse(responseCode = "4006",description = "UNAUTHORIZED, 토큰 모양이 이상함, 토큰 제대로 주세요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4007",description = "UNAUTHORIZED, 엑세스 토큰 만료, 리프레시 토큰 사용",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4010",description = "UNAUTHORIZED, 토큰 없음, 토큰 줘요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4013",description = "BAD_REQUEST, 사용자가 없습니다. 이 api에서 이거 생기면 백앤드 개발자 호출",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "5000",description = "SERVER ERROR, 백앤드 개발자에게 알려주세요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+    })
+    @Parameters({
+            @Parameter(name = "member", hidden = true),
+    })
+    @GetMapping(value = "/members/recipes/{recipeId}")
+    public ResponseDto<RecipeResponseDto.RecipeInfoDto> recipeDetail(@PathVariable(name = "recipeId") Long recipeId, @AuthMember Member member) {
+        return null;
+    }
+
+    @Operation(summary = "🍹figma 레시피2, 레시피 검색 목록조회 화면 API 🔑", description = "검색한 레시피 조회 화면 API입니다. pageIndex로 페이징")
+    @ApiResponses({
+            @ApiResponse(responseCode = "2000",description = "OK, 목록이 있을 땐 이 응답임"),
+            @ApiResponse(responseCode = "2100",description = "OK, 목록이 없을 경우, result = null",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4006",description = "UNAUTHORIZED, 토큰 모양이 이상함, 토큰 제대로 주세요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4007",description = "UNAUTHORIZED, 엑세스 토큰 만료, 리프레시 토큰 사용",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4010",description = "UNAUTHORIZED, 토큰 없음, 토큰 줘요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4013",description = "BAD_REQUEST, 사용자가 없습니다. 이 api에서 이거 생기면 백앤드 개발자 호출",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4018",description = "BAD_REQUEST, 페이지 번호 이상함, -1 이런거 주지 마세요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "5000",description = "SERVER ERROR, 백앤드 개발자에게 알려주세요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+    })
+    @Parameters({
+            @Parameter(name = "member", hidden = true),
+            @Parameter(name = "pageIndex", description = "query string 페이지 번호, 안주면 0으로(최초 페이지) 설정함, -1 이런거 주면 에러 뱉음"),
+            @Parameter(name = "value", description = "query string 검색할 단어")
+    })
+    @GetMapping(value = "/members/recipes/search")
+    public ResponseDto<RecipeResponseDto.RecipeSearchDto> searchRecipe(@RequestParam(name = "value") String value, @AuthMember Member member){
         return null;
     }
 }

--- a/src/main/java/zipdabang/server/web/controller/RecipeController.java
+++ b/src/main/java/zipdabang/server/web/controller/RecipeController.java
@@ -49,7 +49,7 @@ RecipeController {
             @Parameter(name = "member", hidden = true),
     })
     @PostMapping(value = "/members/recipes", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
-    public ResponseDto<RecipeResponseDto.CreateRecipeDto> createRecipe(@ModelAttribute RecipeRequestDto.CreateRecipeDto request, @AuthMember Member member){
+    public ResponseDto<RecipeResponseDto.RecipeStatusDto> createRecipe(@ModelAttribute RecipeRequestDto.CreateRecipeDto request, @AuthMember Member member){
         return null;
     }
 
@@ -60,6 +60,7 @@ RecipeController {
             @ApiResponse(responseCode = "4007",description = "UNAUTHORIZED, 엑세스 토큰 만료, 리프레시 토큰 사용",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
             @ApiResponse(responseCode = "4010",description = "UNAUTHORIZED, 토큰 없음, 토큰 줘요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
             @ApiResponse(responseCode = "4013",description = "BAD_REQUEST, 사용자가 없습니다. 이 api에서 이거 생기면 백앤드 개발자 호출",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4101",description = "BAD_REQUEST, 해당 recipeId를 가진 recipe가 없어요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
             @ApiResponse(responseCode = "5000",description = "SERVER ERROR, 백앤드 개발자에게 알려주세요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
     })
     @Parameters({
@@ -69,6 +70,25 @@ RecipeController {
     public ResponseDto<RecipeResponseDto.RecipeInfoDto> recipeDetail(@PathVariable(name = "recipeId") Long recipeId, @AuthMember Member member) {
         return null;
     }
+
+    @Operation(summary = "🍹figma 나의 레시피 삭제_알럿, 레시피 삭제 API 🔑", description = "레시피 삭제 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "2000", description = "OK, 삭제처리 되었습니다."),
+            @ApiResponse(responseCode = "4006",description = "UNAUTHORIZED, 토큰 모양이 이상함, 토큰 제대로 주세요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4007",description = "UNAUTHORIZED, 엑세스 토큰 만료, 리프레시 토큰 사용",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4010",description = "UNAUTHORIZED, 토큰 없음, 토큰 줘요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4013",description = "BAD_REQUEST, 사용자가 없습니다. 이 api에서 이거 생기면 백앤드 개발자 호출",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4101",description = "BAD_REQUEST, 해당 recipeId를 가진 recipe가 없어요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "5000",description = "SERVER ERROR, 백앤드 개발자에게 알려주세요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+    })
+    @Parameters({
+            @Parameter(name = "member", hidden = true),
+    })
+    @DeleteMapping("/members/recipes/{recipeId}")
+    public ResponseDto<RecipeResponseDto.RecipeStatusDto> deleteRecipe(@PathVariable(name = "recipeId") Long recipeId, @AuthMember Member member){
+        return null;
+    }
+
 
     @Operation(summary = "🍹figma 레시피2, 레시피 검색 목록조회 화면 API 🔑", description = "검색한 레시피 조회 화면 API입니다. pageIndex로 페이징")
     @ApiResponses({
@@ -84,10 +104,128 @@ RecipeController {
     @Parameters({
             @Parameter(name = "member", hidden = true),
             @Parameter(name = "pageIndex", description = "query string 페이지 번호, 안주면 0으로(최초 페이지) 설정함, -1 이런거 주면 에러 뱉음"),
-            @Parameter(name = "value", description = "query string 검색할 단어")
+            @Parameter(name = "keyword", description = "query string 검색할 단어")
     })
     @GetMapping(value = "/members/recipes/search")
-    public ResponseDto<RecipeResponseDto.RecipeSearchDto> searchRecipe(@RequestParam(name = "value") String value, @AuthMember Member member){
+    public ResponseDto<RecipeResponseDto.RecipePageListDto> searchRecipe(@RequestParam(name = "keyword", required = false) String keyword, @RequestParam(name = "pageIndex", required = false) Integer pageIndex, @AuthMember Member member){
+        return null;
+    }
+
+    @Operation(summary = "🍹figma 레시피2, 카테고리 별 레시피 목록 조회 API 🔑", description = "카테고리 별 레시피 목록 조회 화면 API입니다. pageIndex로 페이징")
+    @ApiResponses({
+            @ApiResponse(responseCode = "2000",description = "OK, 목록이 있을 땐 이 응답임"),
+            @ApiResponse(responseCode = "2100",description = "OK, 목록이 없을 경우, result = null",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4006",description = "UNAUTHORIZED, 토큰 모양이 이상함, 토큰 제대로 주세요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4007",description = "UNAUTHORIZED, 엑세스 토큰 만료, 리프레시 토큰 사용",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4010",description = "UNAUTHORIZED, 토큰 없음, 토큰 줘요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4013",description = "BAD_REQUEST, 사용자가 없습니다. 이 api에서 이거 생기면 백앤드 개발자 호출",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4017",description = "BAD_REQUEST, 넘겨받은 categoryId와 일치하는 카테고리 없음. 1~6 사이로 보내세요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4018",description = "BAD_REQUEST, 페이지 번호 이상함, -1 이런거 주지 마세요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "5000",description = "SERVER ERROR, 백앤드 개발자에게 알려주세요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+    })
+    @Parameters({
+            @Parameter(name = "member", hidden = true),
+            @Parameter(name = "pageIndex", description = "query string 페이지 번호, 안주면 0으로(최초 페이지) 설정함, -1 이런거 주면 에러 뱉음"),
+            @Parameter(name = "order", description = "query string 조회 방식. 인기순: likes, 조회순: views, 최신순: latest로 넘겨주세요")
+    })
+    @GetMapping(value = "/members/recipes/categories/{categoryId}")
+    public ResponseDto<RecipeResponseDto.RecipePageListDto> recipeListByCategory(@PathVariable Long categoryId, @RequestParam(name = "order") String order, @RequestParam(name = "pageIndex", required = false) Integer pageIndex, @AuthMember Member member){
+        return null;
+    }
+
+    @Operation(summary = "🍹figma 레시피1, 모든사람/인플루언서/우리들의 레시피 미리보기 API 🔑", description = "5개씩 미리보기로 가져오는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "2000",description = "OK, 목록이 있을 땐 이 응답임"),
+            @ApiResponse(responseCode = "2100",description = "OK, 목록이 없을 경우, result = null",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4006",description = "UNAUTHORIZED, 토큰 모양이 이상함, 토큰 제대로 주세요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4007",description = "UNAUTHORIZED, 엑세스 토큰 만료, 리프레시 토큰 사용",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4010",description = "UNAUTHORIZED, 토큰 없음, 토큰 줘요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4013",description = "BAD_REQUEST, 사용자가 없습니다. 이 api에서 이거 생기면 백앤드 개발자 호출",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "5000",description = "SERVER ERROR, 백앤드 개발자에게 알려주세요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+    })
+    @Parameters({
+            @Parameter(name = "member", hidden = true),
+            @Parameter(name = "writtenby", description = "query string 누가 쓴 레시피 종류인지. 모든 사람: all, 인플루언서: influencer, 우리들: official로 넘겨주세요")
+    })
+    @GetMapping(value = "/members/recipes/types/preview")
+    public ResponseDto<RecipeResponseDto.RecipeListDto> recipeListPreviewWrittenBy(@RequestParam(name = "writtenby") String writtenby, @AuthMember Member member){
+        return null;
+    }
+
+    @Operation(summary = "🍹figma 레시피2, 모든사람/인플루언서/우리들의 레시피 목록 API 🔑", description = "레시피 목록 화면 API입니다. pageIndex로 페이징")
+    @ApiResponses({
+            @ApiResponse(responseCode = "2000",description = "OK, 목록이 있을 땐 이 응답임"),
+            @ApiResponse(responseCode = "2100",description = "OK, 목록이 없을 경우, result = null",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4006",description = "UNAUTHORIZED, 토큰 모양이 이상함, 토큰 제대로 주세요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4007",description = "UNAUTHORIZED, 엑세스 토큰 만료, 리프레시 토큰 사용",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4010",description = "UNAUTHORIZED, 토큰 없음, 토큰 줘요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4013",description = "BAD_REQUEST, 사용자가 없습니다. 이 api에서 이거 생기면 백앤드 개발자 호출",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4017",description = "BAD_REQUEST, 넘겨받은 categoryId와 일치하는 카테고리 없음. 1~6 사이로 보내세요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4018",description = "BAD_REQUEST, 페이지 번호 이상함, -1 이런거 주지 마세요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "5000",description = "SERVER ERROR, 백앤드 개발자에게 알려주세요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+    })
+    @Parameters({
+            @Parameter(name = "member", hidden = true),
+            @Parameter(name = "writtenby", description = "query string 누가 쓴 레시피 종류인지. 모든 사람: all, 인플루언서: influencer, 우리들: official로 넘겨주세요"),
+            @Parameter(name = "pageIndex", description = "query string 페이지 번호, 안주면 0으로(최초 페이지) 설정함, -1 이런거 주면 에러 뱉음"),
+            @Parameter(name = "order", description = "query string 조회 방식. 인기순: likes, 조회순: views, 최신순: latest로 넘겨주세요")
+    })
+    @GetMapping(value = "/members/recipes/types")
+    public ResponseDto<RecipeResponseDto.RecipePageListDto> recipeListWrittenBy(@RequestParam(name = "writtenby") String writtenby, @RequestParam(name = "order") String order, @RequestParam(name = "pageIndex", required = false) Integer pageIndex, @AuthMember Member member){
+        return null;
+    }
+
+    @Operation(summary = "🏠figma 홈1, 주간 베스트 레시피 API 🔑", description = "이번 주 베스트 레시피 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "2000",description = "OK, 목록이 있을 땐 이 응답임"),
+            @ApiResponse(responseCode = "2100",description = "OK, 목록이 없을 경우, result = null",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4006",description = "UNAUTHORIZED, 토큰 모양이 이상함, 토큰 제대로 주세요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4007",description = "UNAUTHORIZED, 엑세스 토큰 만료, 리프레시 토큰 사용",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4010",description = "UNAUTHORIZED, 토큰 없음, 토큰 줘요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4013",description = "BAD_REQUEST, 사용자가 없습니다. 이 api에서 이거 생기면 백앤드 개발자 호출",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "5000",description = "SERVER ERROR, 백앤드 개발자에게 알려주세요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+    })
+    @Parameters({
+            @Parameter(name = "member", hidden = true),
+    })
+    @GetMapping(value = "/members/recipes/week-best")
+    public ResponseDto<RecipeResponseDto.RecipeListDto> recipeWeekBest(@AuthMember Member member){
+        return null;
+    }
+
+    @Operation(summary = "레시피 스크랩/취소 API 🔑", description = "레시피 스크랩/취소 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "2000"),
+            @ApiResponse(responseCode = "4006",description = "UNAUTHORIZED, 토큰 모양이 이상함, 토큰 제대로 주세요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4007",description = "UNAUTHORIZED, 엑세스 토큰 만료, 리프레시 토큰 사용",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4010",description = "UNAUTHORIZED, 토큰 없음, 토큰 줘요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4013",description = "BAD_REQUEST, 사용자가 없습니다. 이 api에서 이거 생기면 백앤드 개발자 호출",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4101",description = "BAD_REQUEST, 해당 recipeId를 가진 recipe가 없어요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "5000",description = "SERVER ERROR, 백앤드 개발자에게 알려주세요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+    })
+    @Parameters({
+            @Parameter(name = "member", hidden = true),
+    })
+    @PostMapping(value = "/members/recipes/{recipeId}/scrap")
+    public ResponseDto<RecipeResponseDto.RecipeStatusDto> recipeScrapOrCancel(@PathVariable Long recipeId, @AuthMember Member member){
+        return null;
+    }
+
+    @Operation(summary = "레시피 좋아요/취소 API 🔑", description = "레시피 좋아요/취소 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "2000"),
+            @ApiResponse(responseCode = "4006",description = "UNAUTHORIZED, 토큰 모양이 이상함, 토큰 제대로 주세요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4007",description = "UNAUTHORIZED, 엑세스 토큰 만료, 리프레시 토큰 사용",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4010",description = "UNAUTHORIZED, 토큰 없음, 토큰 줘요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4013",description = "BAD_REQUEST, 사용자가 없습니다. 이 api에서 이거 생기면 백앤드 개발자 호출",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "4101",description = "BAD_REQUEST, 해당 recipeId를 가진 recipe가 없어요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+            @ApiResponse(responseCode = "5000",description = "SERVER ERROR, 백앤드 개발자에게 알려주세요",content = @Content(schema = @Schema(implementation = ResponseDto.class))),
+    })
+    @Parameters({
+            @Parameter(name = "member", hidden = true),
+    })
+    @PostMapping(value = "/members/recipes/{recipeId}/likes")
+    public ResponseDto<RecipeResponseDto.RecipeStatusDto> recipeLikeOrCancel(@PathVariable Long recipeId, @AuthMember Member member){
         return null;
     }
 }

--- a/src/main/java/zipdabang/server/web/dto/requestDto/RecipeRequestDto.java
+++ b/src/main/java/zipdabang/server/web/dto/requestDto/RecipeRequestDto.java
@@ -10,26 +10,31 @@ import java.util.List;
 
 public class RecipeRequestDto {
 
+    /**
+     * 재정의 필요
+     */
     @Getter @Setter
     public static class CreateRecipeDto{
 
-        Long categoryId;
-        Boolean isInfluencer;
-        String name;
+        List<Long> categoryId;
         MultipartFile thumbnailUrl;
+        String name;
+        String time;
+        String intro;
+        String recipeTip;
+        Integer stepCount;
+        Integer ingredientCount;
         List<StepDto> steps;
         List<NewIngredientDto> ingredients;
     }
 
     public static class NewIngredientDto{
-        private String IngredientName;
+        private String ingredientName;
         private String quantity;
-        private MultipartFile image;
     }
 
     public static class StepDto{
         private Integer stepNum;
-        private String stepTitle;
         private String description;
         private MultipartFile image;
     }

--- a/src/main/java/zipdabang/server/web/dto/responseDto/RecipeResponseDto.java
+++ b/src/main/java/zipdabang/server/web/dto/responseDto/RecipeResponseDto.java
@@ -2,8 +2,11 @@ package zipdabang.server.web.dto.responseDto;
 
 
 import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class RecipeResponseDto {
 
@@ -14,5 +17,73 @@ public class RecipeResponseDto {
     public static class RecipeStatusDto{
         private Long recipeId;
         private LocalDateTime calledAt;
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class RecipeDto {
+        private Long recipeId;
+        List<Long> categoryId;
+        private String recipeName;
+        private String owner;
+        private String thumbnailUrl;
+        private LocalDate createdAt;
+        private Long likes;
+        private Long comments;
+        private Long scraps;
+        private Boolean isLiked;
+        private Boolean isScrapped;
+    }
+
+
+    @Builder
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class RecipeSearchDto {
+        private List<RecipeDto> recipeList;
+        Long totalElements;
+        Integer currentPageElements;
+        Integer totalPage;
+        Boolean isFirst;
+        Boolean isLast;
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class RecipeInfoDto {
+        private RecipeDto recipeInfo;
+        private List<StepDto> steps;
+        private List<IngredientDto> ingredients;
+        private List<CommentDto> comments;
+    }
+
+    public static class IngredientDto{
+        private String IngredientName;
+        private String quantity;
+    }
+
+    public static class StepDto{
+        private Integer stepNum;
+        private String description;
+        private MultipartFile image;
+    }
+
+    public static class CommentDto{
+        private String owner;
+        private String content;
+        private LocalDate createdAt;
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class CreateRecipeDto {
+        private Long recipeId;
     }
 }

--- a/src/main/java/zipdabang/server/web/dto/responseDto/RecipeResponseDto.java
+++ b/src/main/java/zipdabang/server/web/dto/responseDto/RecipeResponseDto.java
@@ -23,7 +23,7 @@ public class RecipeResponseDto {
     @Getter
     @AllArgsConstructor(access = AccessLevel.PROTECTED)
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    public static class RecipeDto {
+    public static class RecipeSimpleDto {
         private Long recipeId;
         List<Long> categoryId;
         private String recipeName;
@@ -37,13 +37,33 @@ public class RecipeResponseDto {
         private Boolean isScrapped;
     }
 
+    @Builder
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class RecipeDto {
+        private Long recipeId;
+        List<Long> categoryId;
+        private String recipeName;
+        private String owner;
+        private String thumbnailUrl;
+        private String time;
+        private String intro;
+        private String recipeTip;
+        private LocalDate createdAt;
+        private Long likes;
+        private Long comments;
+        private Long scraps;
+        private Boolean isLiked;
+        private Boolean isScrapped;
+    }
 
     @Builder
     @Getter
     @AllArgsConstructor(access = AccessLevel.PROTECTED)
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class RecipeSearchDto {
-        private List<RecipeDto> recipeList;
+        private List<RecipeSimpleDto> recipeList;
         Long totalElements;
         Integer currentPageElements;
         Integer totalPage;
@@ -62,17 +82,29 @@ public class RecipeResponseDto {
         private List<CommentDto> comments;
     }
 
+    @Builder
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class IngredientDto{
         private String IngredientName;
         private String quantity;
     }
 
+    @Builder
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class StepDto{
         private Integer stepNum;
         private String description;
         private MultipartFile image;
     }
 
+    @Builder
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class CommentDto{
         private String owner;
         private String content;

--- a/src/main/java/zipdabang/server/web/dto/responseDto/RecipeResponseDto.java
+++ b/src/main/java/zipdabang/server/web/dto/responseDto/RecipeResponseDto.java
@@ -62,7 +62,16 @@ public class RecipeResponseDto {
     @Getter
     @AllArgsConstructor(access = AccessLevel.PROTECTED)
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    public static class RecipeSearchDto {
+    public static class RecipeListDto {
+        private List<RecipeSimpleDto> recipeList;
+        Long totalElements;
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class RecipePageListDto {
         private List<RecipeSimpleDto> recipeList;
         Long totalElements;
         Integer currentPageElements;
@@ -111,11 +120,4 @@ public class RecipeResponseDto {
         private LocalDate createdAt;
     }
 
-    @Builder
-    @Getter
-    @AllArgsConstructor(access = AccessLevel.PROTECTED)
-    @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    public static class CreateRecipeDto {
-        private Long recipeId;
-    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,11 +12,11 @@ spring:
       enabled: always
 
 ##  # local redis
-  redis:
-    host:localhost
-
 #  redis:
-#    host: zipdabang-redis.osattk.ng.0001.apn2.cache.amazonaws.com
+#    host:localhost
+
+  redis:
+    host: zipdabang-redis.osattk.ng.0001.apn2.cache.amazonaws.com
   #  batch:
   #    jdbc:
   #      initialize-schema: always

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,11 +12,11 @@ spring:
       enabled: always
 
 ##  # local redis
-#  redis:
-#    host:localhost
-
   redis:
-    host: zipdabang-redis.osattk.ng.0001.apn2.cache.amazonaws.com
+    host:localhost
+
+#  redis:
+#    host: zipdabang-redis.osattk.ng.0001.apn2.cache.amazonaws.com
   #  batch:
   #    jdbc:
   #      initialize-schema: always


### PR DESCRIPTION
### 🚩 관련 이슈
레시피 api 프론트에서 요청, 응답 json 확인 가능하게 함.

### 📋 PR Checklist
- [x] api 작성
- [x] swagger json 응답 내용 작성
- [x] dto 작성

### 📌 유의사항
레시피 리스트 보여주는건 재활용 가능하게 만들기

### ✅ 테스트 결과
로컬에서 스웨거랑 잘 연동되는 것까지 확인했음
